### PR TITLE
Add support for URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ The fixture definition is structured like this:
 
 ```javascript
 '<path>': {
-  '<HTTP-METHOD>': (body, [delegate]) => httpResponsePromise
+  '<HTTP-METHOD>': (body[, delegate[, params]]) => httpResponsePromise
 }
 ```
 
-The path-string acts as a key (no regex, no order), so make sure they are unique.
+The path-string supports URL parameters using the `:param` syntax.
 
 ### response helpers
 
@@ -94,8 +94,8 @@ const fixture = {
     'GET': () => responses.ok({found: true})
   },
   // define responses for different http methods
-  'user/1': {
-    'GET': () => responses.ok(),
+  'user/:id': {
+    'GET': (body, delegate, params) => responses.ok({ id: params.id }),
     'POST': () => responses.ok({created: true})
     'DELETE': () => responses.unauthorized('user.unauthorized', 'not allowed to delete this user')
   },

--- a/src/effectsFetchFixture.js
+++ b/src/effectsFetchFixture.js
@@ -4,7 +4,7 @@ import URL from 'url-parse';
 import {isString} from 'lodash/lang';
 import {trimStart} from 'lodash/string';
 import {noop} from 'lodash/util';
-import { buildRouteTree, lookupRoute } from "./routing";
+import {buildRouteTree, lookupRoute} from './routing';
 
 /**
  * == Fetch middleware ==

--- a/src/effectsFetchFixture.js
+++ b/src/effectsFetchFixture.js
@@ -4,6 +4,7 @@ import URL from 'url-parse';
 import {isString} from 'lodash/lang';
 import {trimStart} from 'lodash/string';
 import {noop} from 'lodash/util';
+import { buildRouteTree, lookupRoute } from "./routing";
 
 /**
  * == Fetch middleware ==
@@ -12,11 +13,13 @@ import {noop} from 'lodash/util';
  * actions and responses with fixtures defined in this file.
  */
 export default function localFetchMiddleware(fixtures) {
+  const routes = buildRouteTree(fixtures);
+
   return () => next => action => {
     switch (action.type) {
     case FETCH: {
       const {payload: {url, params: {method, body, headers}}} = action;
-      return resolveFixture(fixtures, url, method || 'GET', parseBody(body, headers));
+      return resolveFixture(routes, url, method || 'GET', parseBody(body, headers));
     }
     default:
       return next(action);
@@ -33,7 +36,7 @@ const parseBody = (body, headers) => {
 };
 
 /*eslint-disable  no-console */
-const resolveFixture = (fixtures, urlPath, method, body) => {
+const resolveFixture = (routes, urlPath, method, body) => {
   const url = new URL(`http://localhost${urlPath}`);
   const helpMessage = 'Add a new fixture!';
 
@@ -49,14 +52,14 @@ const resolveFixture = (fixtures, urlPath, method, body) => {
     logBuffer.push(() => console.info('%c[BODY]', 'color: #380B61', body));
   }
 
-  const endpoint = fixtures[url.pathname];
+  const endpoint = lookupRoute(url.pathname, routes);
   if (endpoint === undefined) {
     logBuffer.push(() => console.groupEnd());
     evalLogBuffer(logBuffer);
     throw new Error(`No fixture provided for url: ${url.pathname}. ${helpMessage}`);
   }
 
-  const methodFixture = endpoint[method];
+  const methodFixture = endpoint.methods[method];
   if (methodFixture === undefined) {
     logBuffer.push(() => console.groupEnd());
     evalLogBuffer(logBuffer);
@@ -64,8 +67,8 @@ const resolveFixture = (fixtures, urlPath, method, body) => {
   }
 
   const bodyOrQuery = isGET ? trimStart(url.query, '?') : body;
-  const delegate = (...args) => resolveFixture(fixtures, ...args);
-  const result = methodFixture(bodyOrQuery, delegate);
+  const delegate = (...args) => resolveFixture(routes, ...args);
+  const result = methodFixture(bodyOrQuery, delegate, endpoint.params);
 
   result.then(
     result => {

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,6 +1,4 @@
-import {chain} from 'lodash';
-import {merge, toPairs, findKey, pickBy} from 'lodash/object';
-import {trim} from 'lodash/string';
+import {chain, merge, toPairs, findKey, pickBy, trim} from 'lodash';
 
 const isParam = segment => segment.substr(0, 1) === ':';
 const toSegments = pathname => trim(pathname, '/').split('/');

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,0 +1,78 @@
+import {chain} from 'lodash';
+import {merge, toPairs, findKey, pickBy} from 'lodash/object';
+import {trim} from 'lodash/string';
+
+const isParam = segment => segment.substr(0, 1) === ':';
+const toSegments = pathname => trim(pathname, '/').split('/');
+
+const buildRoute = (segments, methods) => {
+  const segment = segments.shift();
+  const edge = segments.length === 0;
+
+  return {
+    [segment]: merge(
+      { $param: isParam(segment) },
+      edge
+        ? { $edge: edge, $methods: methods }
+        : buildRoute(segments, methods)
+    )
+  };
+}
+
+const buildParams = (param, value) =>
+  param ? { params: { [param.substr(1)]: value } } : {};
+
+const lookup = (segments, routes) => {
+  const segment = segments.shift();
+  const isLastSegment = segments.length === 0;
+  const direct = routes[segment];
+
+  const [param, match] =
+    // check if we have a direct segment match and if we're in the last segment
+    // and if so make sure that this as an edge
+    direct && (isLastSegment ? direct.$edge : true)
+    ? [null, direct]
+
+    // if no explicit segment match is found, look for matching url params
+    : chain(routes)
+      .pickBy(route => route.$param)
+      .toPairs()
+      .head()
+      .value()
+
+    // if we don't find any route with a parameter at this segment, fail
+    // by returning a falsy value for both param and match
+    || [null, null];
+
+  if (!match) {
+    return;
+  }
+
+  if (isLastSegment) {
+    if (match.$edge) {
+      return merge(
+        { methods: match.$methods },
+        buildParams(param, segment)
+      );
+    }
+
+    return;
+  }
+
+  return merge(
+    lookup(segments, match),
+    buildParams(param, segment)
+  );
+}
+
+export const buildRouteTree = (routes) => {
+  return merge.apply(null,
+    toPairs(routes)
+    .map(([route, methods]) => buildRoute(toSegments(route), methods))
+  );
+};
+
+export const lookupRoute = (pathname, routes) => {
+  const segments = toSegments(pathname);
+  return lookup(segments, routes);
+};

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,4 +1,4 @@
-import {chain, merge, toPairs, findKey, pickBy, trim} from 'lodash';
+import {chain, merge, toPairs, trim} from 'lodash';
 
 const isParam = segment => segment.substr(0, 1) === ':';
 const toSegments = pathname => trim(pathname, '/').split('/');
@@ -15,7 +15,7 @@ const buildRoute = (segments, methods) => {
         : buildRoute(segments, methods)
     )
   };
-}
+};
 
 const buildParams = (param, value) =>
   param ? { params: { [param.substr(1)]: value } } : {};
@@ -61,12 +61,12 @@ const lookup = (segments, routes) => {
     lookup(segments, match),
     buildParams(param, segment)
   );
-}
+};
 
 export const buildRouteTree = (routes) => {
-  return merge.apply(null,
-    toPairs(routes)
-    .map(([route, methods]) => buildRoute(toSegments(route), methods))
+  return merge(
+    ...toPairs(routes)
+      .map(([route, methods]) => buildRoute(toSegments(route), methods))
   );
 };
 


### PR DESCRIPTION
As briefly discussed in #10. 

I didn't actually implement regex support, but rather plain `:param` style parameters. I'm passing the values as the third argument to the handler function. Maybe a better option would be to pass a request object, including both the body, params, headers, etc.